### PR TITLE
`Ressya`ディレクティブが空の場合の対応

### DIFF
--- a/src/libs/Oud2JSON.ts
+++ b/src/libs/Oud2JSON.ts
@@ -73,6 +73,12 @@ export class Oud2JSON {
           parent = { ...parent, [objectName]: [...currentArr, updatedObj] };
         }
         idx = nextPointer;
+
+        // `objectName` キーの値をパースした後の整形処理
+        if ((objectName === 'Kudari' || objectName === 'Nobori') && isEmptyObject(parent[objectName])) {
+          parent[objectName] = { Ressya: [] };
+        }
+
         continue;
       }
 

--- a/tests/lib/JSON2Oud.test.ts
+++ b/tests/lib/JSON2Oud.test.ts
@@ -14,5 +14,15 @@ describe('JSON2Oud', () => {
 
       expect(result).toBe(oudFileLines);
     });
+    test('parse with `Ressya` directive data', async () => {
+      // read sample data
+      const { default: expected } = await import('./resources/mock/empty_ressya_patterns');
+      const oudFileLines = fs.readFileSync(path.join(__dirname, './resources/mock/empty_ressya_patterns.oud'), 'utf8');
+
+      const ins = new JSON2Oud(JSON.stringify(expected));
+      const result = ins.parse();
+
+      expect(result).toBe(oudFileLines);
+    });
   });
 });

--- a/tests/lib/Oud2JSON.test.ts
+++ b/tests/lib/Oud2JSON.test.ts
@@ -16,6 +16,18 @@ describe('Oud2JSON', () => {
 
       expect(JSON.parse(result)).toStrictEqual(expected);
     });
+    test('parse with empty `Ressya` directive data', async () => {
+      // read sample data
+      const oudFileLines = fs
+        .readFileSync(path.join(__dirname, './resources/mock/empty_ressya_patterns.oud'), 'utf8')
+        .split('\n');
+
+      const ins = new Oud2JSON(oudFileLines);
+      const result = ins.parse();
+      const { default: expected } = await import('./resources/mock/empty_ressya_patterns');
+
+      expect(JSON.parse(result)).toStrictEqual(expected);
+    });
     test('raise error with invalid data', async () => {
       const oudFileLines = `
       FileType=OuDia.1.02

--- a/tests/lib/resources/mock/empty_ressya_patterns.oud
+++ b/tests/lib/resources/mock/empty_ressya_patterns.oud
@@ -1,0 +1,69 @@
+FileType=OuDia.1.02
+Rosen.
+Rosenmei=eki_patterns
+Eki.
+Ekimei=eki_normal__starting_terminal
+Ekijikokukeisiki=Jikokukeisiki_NoboriChaku
+Ekikibo=Ekikibo_Ippan
+.
+Eki.
+Ekimei=eki_normal__dep_only
+Ekijikokukeisiki=Jikokukeisiki_Hatsu
+Ekikibo=Ekikibo_Ippan
+.
+Eki.
+Ekimei=eki_core__dep_only
+Ekijikokukeisiki=Jikokukeisiki_Hatsu
+Ekikibo=Ekikibo_Syuyou
+.
+Eki.
+Ekimei=eki_normal__dep_and_arrv
+Ekijikokukeisiki=Jikokukeisiki_Hatsuchaku
+Ekikibo=Ekikibo_Ippan
+.
+Eki.
+Ekimei=eki_normal_last_terminal
+Ekijikokukeisiki=Jikokukeisiki_KudariChaku
+Ekikibo=Ekikibo_Ippan
+.
+Ressyasyubetsu.
+Syubetsumei=local
+JikokuhyouMojiColor=00000000
+JikokuhyouFontIndex=0
+DiagramSenColor=00000000
+DiagramSenStyle=SenStyle_Jissen
+StopMarkDrawType=EStopMarkDrawType_Nothing
+.
+Dia.
+DiaName=target_dia
+Kudari.
+.
+Nobori.
+.
+.
+KitenJikoku=400
+DiagramDgrYZahyouKyoriDefault=60
+Comment=comment\nafterbreakline
+.
+DispProp.
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック;Bold=1
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック;Itaric=1
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック;Bold=1;Itaric=1
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+JikokuhyouFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+JikokuhyouVFont=PointTextHeight=9;Facename=@ＭＳ ゴシック
+DiaEkimeiFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+DiaJikokuFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+DiaRessyaFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+CommentFont=PointTextHeight=9;Facename=ＭＳ ゴシック
+DiaMojiColor=00000000
+DiaHaikeiColor=00FFFFFF
+DiaRessyaColor=00000000
+DiaJikuColor=00C0C0C0
+EkimeiLength=6
+JikokuhyouRessyaWidth=6
+.
+FileTypeAppComment=OuDia Ver. 1.02.02

--- a/tests/lib/resources/mock/empty_ressya_patterns.ts
+++ b/tests/lib/resources/mock/empty_ressya_patterns.ts
@@ -1,0 +1,79 @@
+export default {
+  FileType: 'OuDia.1.02',
+  Rosen: [
+    {
+      Rosenmei: 'eki_patterns',
+      Eki: [
+        {
+          Ekimei: 'eki_normal__starting_terminal',
+          Ekijikokukeisiki: 'Jikokukeisiki_NoboriChaku',
+          Ekikibo: 'Ekikibo_Ippan',
+        },
+        {
+          Ekimei: 'eki_normal__dep_only',
+          Ekijikokukeisiki: 'Jikokukeisiki_Hatsu',
+          Ekikibo: 'Ekikibo_Ippan',
+        },
+        {
+          Ekimei: 'eki_core__dep_only',
+          Ekijikokukeisiki: 'Jikokukeisiki_Hatsu',
+          Ekikibo: 'Ekikibo_Syuyou',
+        },
+        {
+          Ekimei: 'eki_normal__dep_and_arrv',
+          Ekijikokukeisiki: 'Jikokukeisiki_Hatsuchaku',
+          Ekikibo: 'Ekikibo_Ippan',
+        },
+        {
+          Ekimei: 'eki_normal_last_terminal',
+          Ekijikokukeisiki: 'Jikokukeisiki_KudariChaku',
+          Ekikibo: 'Ekikibo_Ippan',
+        },
+      ],
+      Ressyasyubetsu: [
+        {
+          Syubetsumei: 'local',
+          JikokuhyouMojiColor: '00000000',
+          JikokuhyouFontIndex: '0',
+          DiagramSenColor: '00000000',
+          DiagramSenStyle: 'SenStyle_Jissen',
+          StopMarkDrawType: 'EStopMarkDrawType_Nothing',
+        },
+      ],
+      Dia: [
+        {
+          DiaName: 'target_dia',
+          Kudari: { Ressya: [] },
+          Nobori: { Ressya: [] },
+        },
+      ],
+      KitenJikoku: '400',
+      DiagramDgrYZahyouKyoriDefault: '60',
+      Comment: 'comment\\nafterbreakline',
+    },
+  ],
+  DispProp: {
+    JikokuhyouFont: [
+      'PointTextHeight=9;Facename=ＭＳ ゴシック',
+      'PointTextHeight=9;Facename=ＭＳ ゴシック;Bold=1',
+      'PointTextHeight=9;Facename=ＭＳ ゴシック;Itaric=1',
+      'PointTextHeight=9;Facename=ＭＳ ゴシック;Bold=1;Itaric=1',
+      'PointTextHeight=9;Facename=ＭＳ ゴシック',
+      'PointTextHeight=9;Facename=ＭＳ ゴシック',
+      'PointTextHeight=9;Facename=ＭＳ ゴシック',
+      'PointTextHeight=9;Facename=ＭＳ ゴシック',
+    ],
+    JikokuhyouVFont: 'PointTextHeight=9;Facename=@ＭＳ ゴシック',
+    DiaEkimeiFont: 'PointTextHeight=9;Facename=ＭＳ ゴシック',
+    DiaJikokuFont: 'PointTextHeight=9;Facename=ＭＳ ゴシック',
+    DiaRessyaFont: 'PointTextHeight=9;Facename=ＭＳ ゴシック',
+    CommentFont: 'PointTextHeight=9;Facename=ＭＳ ゴシック',
+    DiaMojiColor: '00000000',
+    DiaHaikeiColor: '00FFFFFF',
+    DiaRessyaColor: '00000000',
+    DiaJikuColor: '00C0C0C0',
+    EkimeiLength: '6',
+    JikokuhyouRessyaWidth: '6',
+  },
+  FileTypeAppComment: 'OuDia Ver. 1.02.02',
+};


### PR DESCRIPTION
close: #5 

- `Ressya`ディレクティブが空の場合のテストを追加
- `Ressya`ディレクティブが空の場合に`Ressya`キーを明示的に追加する修正
